### PR TITLE
Wait for CI to finish instead of rejecting immediately on bors r+ when CI is still "pending"

### DIFF
--- a/lib/github/github/friendly.ex
+++ b/lib/github/github/friendly.ex
@@ -26,6 +26,7 @@ defmodule BorsNG.GitHub.FriendlyMock do
   @def_files %{".github/bors.toml" => ~s"""
     status = [ "ci" ]
     pr_status = [ "ci" ]
+    prerun_timeout_sec = 5
     delete_merged_branches = true
     """}
   

--- a/lib/github/github/friendly.ex
+++ b/lib/github/github/friendly.ex
@@ -162,7 +162,6 @@ defmodule BorsNG.GitHub.FriendlyMock do
 
   def full_example() do
     alias BorsNG.GitHub.FriendlyMock
-    alias BorsNG.Database
     FriendlyMock.init_state
     FriendlyMock.make_admin
     pr_num = FriendlyMock.add_pr "first"

--- a/lib/github/github/friendly.ex
+++ b/lib/github/github/friendly.ex
@@ -1,0 +1,254 @@
+defmodule BorsNG.GitHub.FriendlyMock do
+  @moduledoc """
+  Helper functions for ServerMock for common operations without having to
+  modify state by hand.
+
+  Tries to lookup values instead of requiring full %{} associative arrays.
+
+  Does everything through webhook notifications. Do not use Repo.insert
+  directly!
+  """
+
+  alias BorsNG.GitHub.ServerMock
+  alias BorsNG.GitHub.FriendlyMock
+  alias BorsNG.GitHub.Pr
+  #alias BorsNG.Database.Installation
+  #alias BorsNG.Database.Project
+  alias BorsNG.WebhookController
+
+  # Defaults
+  @def_user %{"id" => 7,
+	      "login" => "tester",
+	      "avatar_url" => "" }
+  @def_inst 91
+  @def_repo 14
+  @def_files %{".github/bors.toml" => ~s"""
+    status = [ "ci" ]
+    pr_status = [ "ci" ]
+    delete_merged_branches = true
+    """}
+  
+  def init_state() do
+    # Creates a single installation with a single repo where
+    # nothing has happened yet.
+    # Will do everything through webhook notifications. 
+    #inst = %Installation{installation_xref: @def_inst}
+    #|> Repo.insert!()
+    #proj = %Project{
+    #  installation_id: inst.id,
+    #  repo_xref: @def_repo,
+    #  staging_branch: "staging",
+    #  trying_branch: "trying"}
+    #|> Repo.insert!()
+    # Would need more if we wanted to also be able to _list_ repos!
+    ServerMock.put_state(%{
+      {:installation, 91} => %{ repos: [
+          %BorsNG.GitHub.Repo{
+	    id: @def_repo,
+	    name: "test/repo",
+	    owner: %{type: :user,
+		     id: @def_user["id"],
+		     login: @def_user["login"],
+		     avatar_url: @def_user["avatar_url"]}}
+      ] },
+      {{:installation, @def_inst}, @def_repo} => %{
+        branches: %{"master" => "ini"},
+        commits: %{},
+        comments: %{},
+        statuses: %{},
+        files: %{"master" => @def_files,
+		 "staging.tmp" => @def_files},
+	collaborators: %{},
+	pulls: %{},
+	pr_commits: %{}
+      }})
+    WebhookController.do_webhook(%{
+	  body_params: %{
+	    "installation" => %{ "id" => @def_inst },
+	    "sender" => @def_user,
+	    "action" => "created" }}, "github", "installation")
+    BorsNG.Worker.SyncerInstallation.wait_hot_spin_xref(@def_inst)
+  end
+
+  def prs(repo \\ @def_repo, inst \\ @def_inst) do
+    # How can I get both open and unopen PRs?
+    BorsNG.GitHub.get_open_prs!({{:installation, inst}, repo})
+  end
+
+  def comments(repo \\ @def_repo, inst \\ @def_inst) do
+    conn = {{:installation, inst}, repo}
+    state = ServerMock.get_state
+    with({:ok, repo} <- Map.fetch(state, conn),
+         {:ok, comments} <- Map.fetch(repo, :comments),
+      do: comments)
+  end
+
+  def add_pr(title, body \\ nil) do
+    # branch name == title for now
+    number = 1 + Enum.max([0 | Enum.map(prs(), fn x -> x.number end)])
+    sha = "SHA-#{number}"
+    ref = title
+    pr = %Pr{number: number,
+	     title: title,
+	     state: :open,
+	     base_ref: "master",
+	     head_sha: sha,
+	     head_ref: ref,
+	     body: body,
+	     user: @def_user}
+    update_mock([:pulls], &(Map.put(&1, number, pr)))
+    update_mock([:pr_commits], &(Map.put(&1, number, [])))
+    update_mock([:comments], &(Map.put(&1, number, [])))
+    update_mock([:branches], &(Map.put(&1, ref, sha)))
+    update_mock([:files], &(Map.put(&1, sha, @def_files)))
+    update_mock([:statuses], &(Map.put(&1, sha, %{})))
+    WebhookController.do_webhook(%{
+    	  body_params: %{
+    	    "installation" => %{ "id" => @def_inst },
+    	    "sender" => @def_user,
+    	    "repository" => %{ "id" => @def_repo},
+    	    "pull_request" => pr_to_json(pr),
+    	    "action" => "created" }},
+          "github", "pull_request")
+    number
+    #%{body_params: %{
+    #	    "installation" => %{ "id" => @def_inst },
+    #	    "sender" => @def_user,
+    #	    "repository" => %{ "id" => @def_repo},
+    #	    "pull_request" => pr_to_json(pr),
+    #	    "action" => "created" }}
+  end
+
+  def update_mock(path, fun, repo \\ @def_repo, inst \\ @def_inst) do
+    path = [{{:installation, inst}, repo} | path]
+    ServerMock.put_state(update_in(ServerMock.get_state, path, fun))
+  end
+
+  def commits(pr_num, repo \\ @def_repo, inst \\ @def_inst) do
+    BorsNG.GitHub.get_pr_commits!({{:installation, inst}, repo}, pr_num)
+  end
+
+  def add_commit(pr_num, sha, author) do
+    commit = %{sha: sha,
+	       author_name: author,
+	       author_email: author <> "'s email"}
+    # Could maybe prepend to make things faster
+    update_mock([:pr_commits, pr_num], &(&1 ++ [commit]))
+  end
+
+  def add_comment(pr_num, body, author \\ @def_user) do
+    pr = Enum.find(prs(), &(match?(%{number: ^pr_num}, &1)))
+    # number = 1 + Enum.max([0 | Enum.map(comments(), fn x -> x.number end)])
+    #comment = [body]
+    #update_mock([:comments], &(Map.put(&1, pr_num, comment)))
+    update_mock([:comments, pr_num], &([body | &1]))
+    WebhookController.do_webhook(
+      %{
+	  body_params: %{
+	    "sender" => author,
+    	    "repository" => %{ "id" => @def_repo},
+	    "comment" => %{ "user" => author,
+			    "body" => body },
+	    "pull_request" => pr_to_json(pr),
+	    "action" => "created" }} , "github", "pull_request_review_comment")
+  end
+
+  def make_admin(username \\ @def_user["login"]) do
+    alias BorsNG.Database
+    user = Database.Repo.get_by! Database.User, login: username
+    Database.Repo.update! Database.User.changeset(user, %{is_admin: true})
+  end
+
+
+  def add_reviewer(repo \\ @def_repo, user \\ @def_user) do
+    alias BorsNG.Database
+    alias BorsNG.Database.Repo
+    #use Phoenix.ConnTest
+
+    #import Ecto
+    #import Ecto.Changeset
+    #import Ecto.Query
+
+    #import BorsNG.Router.Helpers
+    # Could instead post html instead of calling add_reviewer directly.
+    # See test/controllers/project_controller_test.exs
+    #phx_conn = Phoenix.ConnTest.build_conn()
+    project = Repo.get_by!(Database.Project, %{repo_xref: repo})
+    BorsNG.ProjectController.add_reviewer(nil, :rw, project, %{"reviewer" => user})
+    #conn = conn
+    #|> login()
+    #|> post(
+    #  project_path(conn, :add_reviewer, project),
+    #%{"reviewer" => %{"login" => "case"}})
+    #resp = conn
+    #|> get(redirected_to(conn, 302))
+    #|> html_response(200)
+  end
+
+  def ci_status(hash, ci_name, status) do
+    update_mock([:statuses, hash], &(Map.put(&1, ci_name, status)))
+  end
+
+  def full_example() do
+    alias BorsNG.GitHub.FriendlyMock
+    alias BorsNG.Database
+    # ServerMock.put_state(old_state)
+    FriendlyMock.init_state
+    FriendlyMock.make_admin
+    FriendlyMock.add_pr "first"
+    #FriendlyMock.add_pr "First pull request"
+    FriendlyMock.add_pr "Second pull request"
+    FriendlyMock.add_commit(2, "000002", "Tester")
+    FriendlyMock.add_commit(2, "000003", "Tester")
+    FriendlyMock.add_comment(2, "Hello world")
+    Database.Repo.all Database.User
+    Database.Repo.all Database.Project
+    Database.Repo.all Database.Patch
+    FriendlyMock.add_reviewer
+    FriendlyMock.add_comment(2, "bors r+")
+    ServerMock.get_state
+  end
+
+  def run_once() do
+    alias BorsNG.GitHub.FriendlyMock
+    alias BorsNG.Database
+    FriendlyMock.init_state
+    FriendlyMock.make_admin
+    FriendlyMock.add_pr "first"
+    FriendlyMock.add_reviewer
+    FriendlyMock.ci_status("SHA-1", "ci", :running)
+    FriendlyMock.add_comment(1, "bors ping")
+    FriendlyMock.add_comment(1, "bors r+")
+    #FriendlyMock.ci_status("SHA-1", "ci", :ok)
+  end
+
+  def pr_to_json(%Pr{number: number,
+		     title: title,
+		     state: state,
+		     base_ref: base_ref,
+		     head_sha: head_sha,
+		     body: body,
+		     user: user}) do
+    %{
+    "number" => number,
+    "title" => title,
+    "body" => body,
+    "state" => Atom.to_string(state),
+    "base" => %{
+      "ref" => base_ref,
+      "repo" => %{
+        "id" => 0 #base_repo_id
+      }
+    },
+    "head" => %{
+      "sha" => head_sha,
+      "ref" => "0000",
+      "repo" => %{
+        "id" => "0"
+      }
+    },
+    "user" => user,
+    "merged_at" => "some non-nul time :)",
+    }
+  end
+end

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -338,7 +338,6 @@ defmodule BorsNG.GitHub.ServerMock do
   end
 
   def do_handle_call(:get_file, repo_conn, {branch, path}, state) do
-    IO.inspect([:debug, branch, path])
     with({:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, files} <- Map.fetch(repo, :files),
       do: {:ok, files[branch][path]})

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -338,6 +338,7 @@ defmodule BorsNG.GitHub.ServerMock do
   end
 
   def do_handle_call(:get_file, repo_conn, {branch, path}, state) do
+    IO.inspect([:debug, branch, path])
     with({:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, files} <- Map.fetch(repo, :files),
       do: {:ok, files[branch][path]})

--- a/lib/web/controllers/project_controller.ex
+++ b/lib/web/controllers/project_controller.ex
@@ -283,9 +283,13 @@ defmodule BorsNG.ProjectController do
             {:ok, "Successfully added #{user.login} as a reviewer"}
         end
     end
-    conn
-    |> put_flash(state, msg)
-    |> redirect(to: project_path(conn, :settings, project))
+    case conn do
+      nil -> msg
+      conn ->
+        conn
+        |> put_flash(state, msg)
+        |> redirect(to: project_path(conn, :settings, project))
+    end
   end
 
   def add_member(_, :ro, _, _), do: raise BorsNG.PermissionDeniedError

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -576,6 +576,9 @@ defmodule BorsNG.Worker.Batcher do
     |> GitHub.get_labels!(patch.pr_xref)
     |> MapSet.new()
     |> MapSet.disjoint?(MapSet.new(toml.block_labels))
+    # This seems to treat unset statuses as :ok. Dangerous is CI
+    # is slower to set an at least pending status before someone types
+    # bors r+.
     no_error_status = repo_conn
     |> GitHub.get_commit_status!(patch.commit)
     |> Enum.filter(fn {_, status} -> status == :error end)

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -247,7 +247,7 @@ defmodule BorsNG.Worker.Batcher do
     end
     poll_after_delay(project)
     # Maybe not needed because bors adds a commit referencing this.
-    send_message(repo_conn, [patch], {:preflight, :ok})
+    #send_message(repo_conn, [patch], {:preflight, :ok})
     send_status(repo_conn, batch.id, [patch], :waiting)
   end
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -120,7 +120,6 @@ defmodule BorsNG.Worker.Batcher do
           :ok ->
 	    run(reviewer, patch)
           :waiting ->
-	    # Not quite right. Need to add new message.
 	    send_message(repo_conn, [patch], {:preflight, :waiting})
 	    prerun_poll({reviewer, patch})
           {:error, message} ->

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -15,6 +15,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
   defstruct status: [], block_labels: [], pr_status: [],
     timeout_sec: (60 * 60),
+    # Half an hour. Give up when more time is spent waiting for this amount
+    # between two successive polls.
+    prerun_timeout_sec: (30 * 60),
     required_approvals: nil,
     cut_body_after: nil,
     delete_merged_branches: false,
@@ -29,6 +32,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
     block_labels: [binary],
     pr_status: [binary],
     timeout_sec: integer,
+    prerun_timeout_sec: integer,
     required_approvals: integer | nil,
     cut_body_after: binary | nil,
     delete_merged_branches: boolean,
@@ -38,6 +42,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
     :block_labels |
     :pr_status |
     :timeout_sec |
+    :prerun_timeout_sec |
     :required_approvals |
     :cut_body_after |
     :committer_details |
@@ -72,6 +77,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           block_labels: Map.get(toml, "block_labels", []),
           pr_status: Map.get(toml, "pr_status", []),
           timeout_sec: Map.get(toml, "timeout_sec", 60 * 60),
+          prerun_timeout_sec: Map.get(toml, "prerun_timeout_sec", 30 * 60),
           required_approvals: Map.get(toml, "required_approvals", nil),
           cut_body_after: Map.get(toml, "cut_body_after", nil),
           delete_merged_branches: Map.get(toml,
@@ -88,6 +94,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             {:error, :pr_status}
           %{timeout_sec: timeout_sec} when not is_integer timeout_sec ->
             {:error, :timeout_sec}
+          %{prerun_timeout_sec: prerun_timeout_sec} when not is_integer prerun_timeout_sec ->
+            {:error, :prerun_timeout_sec}
           %{required_approvals: req_approve} when not is_integer(req_approve) and not is_nil(req_approve) ->
             {:error, :required_approvals}
           %{cut_body_after: c} when (not is_binary c) and (not is_nil c) ->

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -29,7 +29,7 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_message({:preflight, :waiting}) do
-    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when the status is set."
+    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."
   end
   def generate_message({:preflight, :ok}) do
     "All preflight checks passed. Batching this PR into the staging branch."

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -29,7 +29,7 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_message({:preflight, :waiting}) do
-    ":clock1: Waiting for PR status (Github check) to be set, probably by CI."
+    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when the status is set."
   end
   def generate_message({:preflight, :ok}) do
     "All preflight checks passed. Batching this PR into the staging branch."

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -28,6 +28,15 @@ defmodule BorsNG.Worker.Batcher.Message do
     {"Delayed for higher-priority pull requests", :running}
   end
 
+  def generate_message({:preflight, :waiting}) do
+    ":clock1: Waiting for PR status (Github check) to be set, probably by CI."
+  end
+  def generate_message({:preflight, :ok}) do
+    "All preflight checks passed. Batching this PR into the staging branch."
+  end
+  def generate_message({:preflight, :timeout}) do
+    "Timeout waiting for PR status (Github check). Likely CI was taking too long."
+  end
   def generate_message({:preflight, :blocked_labels}) do
     ":-1: Rejected by label"
   end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -311,6 +311,98 @@ defmodule BorsNG.Worker.BatcherTest do
       }}
   end
 
+  test "Poll on a pending (waiting) PR status. Then reject after that CI fails.", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }})
+    patch = %Patch{
+      project_id: proj.id,
+      pr_xref: 1,
+      commit: "Z",
+      into_branch: "master"}
+    |> Repo.insert!()
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":clock1: Waiting for PR status (Github check) to be set, probably by CI."]},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+    path = [{{:installation, 91}, 14}, :statuses, "Z"]
+    GitHub.ServerMock.put_state(update_in(GitHub.ServerMock.get_state,
+	  path,
+	  &(Map.put(&1, "cn", :error))))
+    Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":-1: Rejected by PR status", ":clock1: Waiting for PR status (Github check) to be set, probably by CI."]},
+        statuses: %{"Z" => %{"cn" => :error}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+  end
+
+  test "Poll on a pending (waiting) PR status. Then accept after that CI succeeds.", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }})
+    patch = %Patch{
+      project_id: proj.id,
+      pr_xref: 1,
+      commit: "Z",
+      into_branch: "master"}
+    |> Repo.insert!()
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":clock1: Waiting for PR status (Github check) to be set, probably by CI."]},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+    path = [{{:installation, 91}, 14}, :statuses, "Z"]
+    GitHub.ServerMock.put_state(update_in(GitHub.ServerMock.get_state,
+	  path,
+	  &(Map.put(&1, "cn", :ok))))
+    Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":clock1: Waiting for PR status (Github check) to be set, probably by CI."]},
+        statuses: %{"Z" => %{"cn" => :ok, "bors" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+  end
+
   test "rejects a patch with a requested changes", %{proj: proj} do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{


### PR DESCRIPTION
Allows devs to type `bors r+` before CI finishes. Bors waits for CI to timeout (this value can be set by `prerun_timeout_sec` in `bors.toml`).