### PR TITLE
[PS-21556] Make Bors run and commit simformat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "simformat"]
+	path = simformat
+	url = git@github.com:Simspace/simformat.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 ARG ELIXIR_VERSION=1.11.4
 ARG SOURCE_COMMIT
 
+# SimSpace-format begin
 FROM haskell:8.10.4-buster as haskell-builder
 COPY simformat /simformat
 RUN cd simformat && stack install simformat --local-bin-path=/usr/local/bin
+# SimSpace-format end
 
 FROM elixir:${ELIXIR_VERSION} as builder
 
@@ -54,7 +56,9 @@ RUN curl -Ls https://github.com/bors-ng/dockerize/releases/download/v0.7.9/docke
 ADD ./script/docker-entrypoint /usr/local/bin/bors-ng-entrypoint
 COPY --from=builder /src/_build/prod/rel/ /app/
 
+# SimSpace-format begin
 COPY --from=haskell-builder /usr/local/bin/simformat /usr/local/bin/simformat
+# SimSpace-format end
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PORT=4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 ARG ELIXIR_VERSION=1.11.4
 ARG SOURCE_COMMIT
 
+FROM haskell:8.10.4-buster as haskell-builder
+COPY simformat /simformat
+RUN cd simformat && stack install simformat --local-bin-path=/usr/local/bin
+
 FROM elixir:${ELIXIR_VERSION} as builder
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -49,6 +53,8 @@ RUN curl -Ls https://github.com/bors-ng/dockerize/releases/download/v0.7.9/docke
 
 ADD ./script/docker-entrypoint /usr/local/bin/bors-ng-entrypoint
 COPY --from=builder /src/_build/prod/rel/ /app/
+
+COPY --from=haskell-builder /usr/local/bin/simformat /usr/local/bin/simformat
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PORT=4000

--- a/SIMSPACE.md
+++ b/SIMSPACE.md
@@ -1,0 +1,4 @@
+# SimSpace specific changes in this repository, things you don't want to push upstream
+
+- The simformat git submodule
+- The Dockerfile includes the simformat binary. Changes specific to simspace are between "# SimSpace-format begin" and "# SimSpace-format end"


### PR DESCRIPTION
[PS-21556] Make Bors run and commit simformat
https://ticket.simspace.com/browse/PS-21556

The destination for the binary matches a directory in the PATH as shown with `docker inspect <container>`. 

This has been tested with a locally running bors-ng and simformat in the $PATH.
Reordering of imports can be seen in the repo under test: https://github.com/shapr/bloohm/commit/03c3f2e3f78f781188b4580b73ba7eeb7815dc09

Thanks to much help from @wyao-simspace I was able to test these changes inside the docker container: https://github.com/shapr/bloohm/commit/6b4f5f87c7917d53538b2cd8f0616cd03fff7033
